### PR TITLE
Restrict testing to US regions.

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -24,3 +24,9 @@ variable "oidc_provider_arn" {
   type        = string
   default     = ""
 }
+
+variable "region" {
+  description = "The AWS region to deploy into"
+  type        = string
+  default     = "us-east-2"
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -12,3 +12,7 @@ terraform {
     }
   }
 }
+
+provider "aws" {
+  region = var.region
+}

--- a/test/utils/test_cases.go
+++ b/test/utils/test_cases.go
@@ -1,14 +1,14 @@
 package utils
 
 import (
-	"os"
-	"sync"
-	"testing"
-    "strings"
-	"regexp"
 	"fmt"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	testStructure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
 )
 
 type TestCase struct {
@@ -55,6 +55,7 @@ func FormatName(name string, serviceAccount string) string {
 	result := fmt.Sprintf("%s-%s-%s", name, trimmedServiceAccount, "irsa")
 	return result
 }
+
 // Function for removing randomly generated hexadecimal characters from the role arn (required for testing in parallel)
 func StripHexadecimal(input string) string {
 	regex_hex := regexp.MustCompile(`-[0-9a-fA-F]+-irsa$`)


### PR DESCRIPTION
Tested with `go test` in `test` dir to observe testing in different US regions.